### PR TITLE
Added escapeshellarg() around filepath

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -129,7 +129,8 @@ class Factory
         }
 
         $phpBinary = PHP_BINARY . (PHP_SAPI === 'phpdbg' ? ' -qrr --' : '');
-        $command = $phpBinary . ' ' . __DIR__ . DIRECTORY_SEPARATOR . 'child-process.php';
+        $childProcessPath = \escapeshellarg(__DIR__ . DIRECTORY_SEPARATOR . 'child-process.php');
+        $command = $phpBinary . ' ' . $childProcessPath;
         $process = new Process(
             sprintf(
                 $template,


### PR DESCRIPTION
If the project file path contains special characters (e.g. spaces in parent folder-names), the child-process.php wouldn't be able to execute.