### PR TITLE
Support for advanced own child from examples

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -28,10 +28,10 @@ final class Factory
     ) {
         return new Promise\Promise(function ($resolve, $reject) use ($process, $loop, $options) {
             $server = new Server('127.0.0.1:0', $loop);
-            $argvString = \escapeshellarg(ArgvEncoder::encode([
-                'address' => $server->getAddress(),
-            ]));
 
+            $options['random'] = \bin2hex(\random_bytes(32));
+            $options['address'] = $server->getAddress();
+            $argvString = \escapeshellarg(ArgvEncoder::encode($options));
             $process = new Process($process->getCommand() . ' ' . $argvString);
 
             self::startParent($process, $server, $loop, $options)->done($resolve, $reject);


### PR DESCRIPTION
Fix when `address` and `random` options was not filled.
I have problems with running example of [advanced-own-child-process](https://github.com/WyriHaximus/reactphp-child-process-messenger/blob/69005749c72282d9c18ca19c425e79f8e454d69e/examples/advanced-own-child-process/parent.php) and this fix it.