### PR TITLE
Update ChildInterface.php

### DIFF
--- a/src/ChildInterface.php
+++ b/src/ChildInterface.php
@@ -8,5 +8,5 @@ use React\EventLoop\LoopInterface;
 
 interface ChildInterface
 {
-    public static function create(Messenger $messenger, LoopInterface $loop): void;
+    public static function create(Messenger $messenger, LoopInterface $loop);
 }


### PR DESCRIPTION
Some reactphp component are not support return type because they support >=5.4. When we use reactphp/filesystem it doesn't work. I think we don't need return type declaration 

Incompatiable package
https://github.com/reactphp/filesystem/blob/master/src/ChildProcess/Process.php#L18