### PR TITLE
Change interface return type to mixed

### DIFF
--- a/src/ChildInterface.php
+++ b/src/ChildInterface.php
@@ -8,5 +8,5 @@ use React\EventLoop\LoopInterface;
 
 interface ChildInterface
 {
-    public static function create(Messenger $messenger, LoopInterface $loop): void;
+    public static function create(Messenger $messenger, LoopInterface $loop): mixed;
 }


### PR DESCRIPTION
The `react/filesystem` will report this error.

> PHP Fatal error:  Declaration of React\Filesystem\ChildProcess\Process::create(WyriHaximus\React\ChildProcess\Messenger\Messenger $messenger, React\EventLoop\LoopInterface $loop): mixed must be compatible with WyriHaximus\React\ChildProcess\Messenger\ChildInterface::create(WyriHaximus\React\ChildProcess\Messenger\Messenger $messenger, React\EventLoop\LoopInterface $loop): void


