### PR TITLE
Cleanup circular reference between $server and event listener

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -213,9 +213,11 @@ final class Factory
                         return Promise\reject(new RuntimeException('Handshake failed'));
                     })->then(static function (MessengerInterface $messenger) use ($server, $resolve): void {
                         $server->close();
+                        $server->removeAllListeners('connection');
                         $resolve($messenger);
                     }, static function (Throwable $throwable) use ($server, $reject): void {
                         $server->close();
+                        $server->removeAllListeners();
                         $reject($throwable);
                     });
                 }
@@ -227,6 +229,7 @@ final class Factory
             $process->start($loop);
         }, static function () use ($server, $process): void {
             $server->close();
+            $server->removeAllListeners();
             $process->terminate();
         }))->then(static function (Messenger $messenger) use ($loop, $process): Messenger {
             $loop->addPeriodicTimer(self::INTERVAL, static function (TimerInterface $timer) use ($messenger, $loop, $process): void {

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -56,4 +56,18 @@ final class FactoryTest extends TestCase
         );
         self::assertSame(['foo' => 'bar'], $payload->getPayload());
     }
+
+    public function testNoGarbageCollectionAfterSuccessfulRun(): void
+    {
+        \gc_collect_cycles();
+        $payload = await(
+            Factory::parentFromClass(ReturnChild::class, $this->loop)->then(
+                static function (MessengerInterface $messenger): PromiseInterface {
+                    return $messenger->rpc(MessagesFactory::rpc('return', ['foo' => 'bar']));
+                }
+            ),
+            $this->loop
+        );
+        $this->assertSame(0, \gc_collect_cycles());
+    }
 }


### PR DESCRIPTION
While tracking down memory growth on a long running process using ReactPHP Filesystem I came across the following circular reference that needs to be cleaned up by the GC.

Circular reference between $server and the connection event listener causes garbage collection cycles when resolving.

I've additionally added removing listeners on all instances of closing the server, tests coverage is only for the success route.