### PR TITLE
Cache the Doctrine\Inflector instance as a static property for reuse

### DIFF
--- a/src/Messages/Factory.php
+++ b/src/Messages/Factory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WyriHaximus\React\ChildProcess\Messenger\Messages;
 
+use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Exception;
 use Throwable;
@@ -12,13 +13,16 @@ use function Safe\json_decode;
 
 final class Factory
 {
+    private static ?Inflector $inflector = null;
+
     /**
      * @param array<mixed> $lineOptions
      */
     public static function fromLine(string $line, array $lineOptions): ActionableMessageInterface
     {
         $line   = json_decode($line, true);
-        $method = InflectorFactory::create()->build()->camelize($line['type']);
+        self::$inflector ??= InflectorFactory::create()->build();
+        $method = self::$inflector->camelize($line['type']);
         if ($method === 'secure') {
             return static::secureFromLine($line, $lineOptions);
         }


### PR DESCRIPTION
Adds a private static property to the Messages Factory to only create a single reusable instance of Doctrine\Inflector. In the benchmark\memory.php test this reduces peak memory by 40MB for 100000 RPC calls and improves benchmark performance by 60-80% in testing. A bonus is improved readability of XDebug traces without all the Doctrine calls in each call.

Closes #112