### PR TITLE
Allow thecodingmachine/safe 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "react/promise-timer": "^1.6",
         "react/socket": "^1.9",
         "symfony/polyfill-php81": "^1.23",
-        "thecodingmachine/safe": "^1.3.3",
+        "thecodingmachine/safe": "^1.3.3 || ^2.0",
         "wyrihaximus/composer-update-bin-autoload-path": "^1.1.1",
         "wyrihaximus/constants": "^1.6",
         "wyrihaximus/file-descriptors": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d23fe8780be7773309e94f6c62b29c5f",
+    "content-hash": "c5a9b5caeeed80b7daf0622bcf289e15",
     "packages": [
         {
             "name": "cakephp/core",
@@ -4114,12 +4114,12 @@
             "version": "5.2.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
+                "url": "https://github.com/jsonrainbow/json-schema.git",
                 "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
                 "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
                 "shasum": ""
             },
@@ -8046,12 +8046,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
@@ -9999,7 +9999,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -10007,7 +10007,7 @@
         "ext-hash": "^8 || ^7.4",
         "ext-json": "^8 || ^7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4.7"
     },


### PR DESCRIPTION
To prevent a lot of deprecation messages when running version 1 on PHP 8.4